### PR TITLE
Add compact view option

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,8 @@
+# Mizzou GI Schedule
+
+This project displays weekly schedules for the University of Missouri Division of Gastroenterology & Hepatology. The `index.html` file reads CSV data for each week and renders a table.
+
+## Compact view
+
+A "View Mode" selector appears next to the week selector. Choose **Compact** to reduce font sizes and remove sticky columns so the entire table fits on small screens. Switch back to **Standard** for the default layout.
+

--- a/index.html
+++ b/index.html
@@ -61,6 +61,9 @@
             max-height: 75vh;
             overflow-y: auto;
         }
+        .table-container.compact-view table {
+            min-width: 600px;
+        }
         table {
             width: 100%;
             border-collapse: collapse;
@@ -71,6 +74,11 @@
             text-align: left;
             border-bottom: 1px solid #e5e7eb;
             font-size: 0.875rem;
+        }
+        .compact-view th,
+        .compact-view td {
+            font-size: 0.625rem;
+            padding: 0.25rem;
         }
         th {
             background-color: var(--mizzou-black);
@@ -97,6 +105,15 @@
             position: sticky;
             background-color: white;
             z-index: 5;
+        }
+        .compact-view thead th,
+        .compact-view tbody td {
+            position: static !important;
+            left: auto !important;
+        }
+        .compact-view tbody td:nth-child(1),
+        .compact-view tbody td:nth-child(2) {
+            min-width: auto;
         }
         tbody td:nth-child(1) {
             left: 0;
@@ -157,6 +174,12 @@
             font-weight: 500;
             padding: 0.25rem 0.5rem;
             border-radius: 0.25rem;
+        }
+        .compact-view .orientation-cell,
+        .compact-view .holiday-cell,
+        .compact-view .july4-cell {
+            font-size: 0.625rem;
+            padding: 0.25rem;
         }
 
         /* General holiday cell styling */
@@ -233,6 +256,13 @@
                 <label for="week-select" class="block text-lg font-medium text-gray-700 mb-2">Select Week</label>
                 <select id="week-select" class="w-full sm:w-auto">
                     <!-- Options will be populated by JavaScript -->
+                </select>
+            </div>
+            <div class="mt-4 sm:mt-0">
+                <label for="view-select" class="block text-lg font-medium text-gray-700 mb-2">View Mode</label>
+                <select id="view-select" class="w-full sm:w-auto">
+                    <option value="standard">Standard</option>
+                    <option value="compact">Compact</option>
                 </select>
             </div>
         </div>
@@ -480,9 +510,20 @@ function createTableHeaders(startDate) {
             }
         }
 
+        function updateView() {
+            const container = document.getElementById('schedule-container');
+            const view = document.getElementById('view-select').value;
+            if (view === 'compact') {
+                container.classList.add('compact-view');
+            } else {
+                container.classList.remove('compact-view');
+            }
+        }
+
         // Initialize the application
         function init() {
             const weekSelect = document.getElementById('week-select');
+            const viewSelect = document.getElementById('view-select');
             const weeks = generateWeeks();
             
             // Populate dropdown
@@ -497,14 +538,17 @@ function createTableHeaders(startDate) {
             // Set current week
             const currentWeekIndex = getCurrentWeek(weeks);
             weekSelect.selectedIndex = currentWeekIndex;
+            viewSelect.value = 'standard';
             
             // Load the schedule for the selected week
             loadSchedule(weekSelect.value, weeks[currentWeekIndex].startDate);
+            updateView();
             
             // Handle week selection change
             weekSelect.addEventListener('change', (e) => {
                 loadSchedule(e.target.value, weeks[e.target.selectedIndex].startDate);
             });
+            viewSelect.addEventListener('change', updateView);
         }
 
 


### PR DESCRIPTION
## Summary
- add a view-mode selector for Standard or Compact layouts
- implement `.compact-view` styles to shrink table and disable sticky columns
- switch view via JavaScript
- document compact view in README

## Testing
- `npm test` *(fails: package.json missing)*
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_685cc2c739308333ae6e801f1ac4ff95