### PR TITLE
Improve mobile schedule layout

### DIFF
--- a/index.html
+++ b/index.html
@@ -151,6 +151,11 @@
             border-top: 1px solid #e5e7eb;
             margin: 0.125rem 0;
         }
+        .slot-indicator {
+            font-weight: 600;
+            font-size: 0.65rem;
+            color: var(--mizzou-black);
+        }
         /* Cell content styling */
         td {
             text-align: center;
@@ -207,17 +212,25 @@
         /* Mobile responsiveness */
         @media (max-width: 768px) {
             th, td {
-                padding: 0.25rem;
+                padding: 0.125rem;
                 font-size: 0.625rem;
             }
             .controls {
                 padding: 0.5rem;
             }
             tbody td:nth-child(1) {
-                min-width: 100px;
+                min-width: 80px;
             }
             table {
                 min-width: 700px;
+            }
+            .pgy-badge {
+                font-size: 0.5rem;
+                padding: 0.0625rem 0.125rem;
+                margin-left: 0.125rem;
+            }
+            .slot-indicator {
+                font-size: 0.55rem;
             }
             .orientation-cell,
             .holiday-cell,
@@ -493,7 +506,12 @@ function createTableHeaders(startDate, mobile = false) {
                             const am = row[d === 0 ? 'AM' : `AM${d + 1}`] || '';
                             const pm = row[d === 0 ? 'PM' : `PM${d + 1}`] || '';
                             const isDivider = d < 4;
-                            cells.push(`<td${isDivider ? ' class="day-divider"' : ''}>${styleCellContent(am)}<hr class="am-pm-separator">${styleCellContent(pm)}</td>`);
+                            cells.push(`
+                                <td${isDivider ? ' class="day-divider"' : ''}>
+                                    <span class="slot-indicator">AM</span> ${styleCellContent(am)}
+                                    <hr class="am-pm-separator">
+                                    <span class="slot-indicator">PM</span> ${styleCellContent(pm)}
+                                </td>`);
                         }
                     } else {
                         // Add AM/PM slots (skip NAME and PGY columns)


### PR DESCRIPTION
## Summary
- refine name column width and badge size on mobile
- add small AM/PM indicators in mobile view

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_685cc71b95e88333b64305e87b815932