### PR TITLE
Improve mobile view compactness

### DIFF
--- a/index.html
+++ b/index.html
@@ -103,6 +103,9 @@
             z-index: 5;
             font-weight: 600;
             min-width: 170px;
+            max-width: 170px;
+            overflow: hidden;
+            text-overflow: ellipsis;
         }
         .compact-view thead th,
         .compact-view tbody td {
@@ -219,10 +222,16 @@
                 padding: 0.5rem;
             }
             tbody td:nth-child(1) {
-                min-width: 80px;
+                min-width: 60px;
+                max-width: 60px;
+                overflow: hidden;
+                text-overflow: ellipsis;
+            }
+            thead th:nth-child(1) {
+                min-width: 60px;
             }
             table {
-                min-width: 700px;
+                min-width: 600px;
             }
             .pgy-badge {
                 font-size: 0.5rem;
@@ -237,6 +246,14 @@
             .july4-cell {
                 font-size: 0.625rem;
                 padding: 0.25rem;
+            }
+        }
+        @media (max-width: 480px) {
+            .pgy-badge {
+                display: none;
+            }
+            .view-mode-container {
+                display: none;
             }
         }
         /* Loading spinner */
@@ -265,7 +282,7 @@
                     <!-- Options will be populated by JavaScript -->
                 </select>
             </div>
-            <div class="mt-4 sm:mt-0">
+            <div class="mt-4 sm:mt-0 view-mode-container">
                 <label for="view-select" class="block text-lg font-medium text-gray-700 mb-2">View Mode</label>
                 <select id="view-select" class="w-full sm:w-auto">
                     <option value="standard">Standard</option>
@@ -400,6 +417,7 @@
         // Create table headers
 function createTableHeaders(startDate, mobile = false) {
             const days = ['Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday'];
+            const labels = mobile ? days.map(d => d.slice(0, 3)) : days;
             const dates = days.map((_, idx) => {
                 const d = new Date(startDate);
                 d.setDate(d.getDate() + idx);
@@ -410,7 +428,7 @@ function createTableHeaders(startDate, mobile = false) {
                 const headerHtml = `
                     <tr>
                         <th>NAME</th>
-                        ${days.map((day, i) => `<th class="day-header">${day}<br>${dates[i]}</th>`).join('')}
+                        ${labels.map((day, i) => `<th class="day-header">${day}<br>${dates[i]}</th>`).join('')}
                     </tr>
                 `;
                 return headerHtml;


### PR DESCRIPTION
## Summary
- restrict the sticky name column width and truncate long names
- shrink table and name column in mobile view
- hide PGY badges and view selector on very small screens
- shorten day headers to three-letter abbreviations on mobile

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_685cc8c090b8833392645082f063c205