### PR TITLE
Remove compact view dropdown

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,10 +2,6 @@
 
 This project displays weekly schedules for the University of Missouri Division of Gastroenterology & Hepatology. The `index.html` file reads CSV data for each week and renders a table.
 
-## Compact view
-
-A "View Mode" selector appears next to the week selector. Choose **Compact** to reduce font sizes and remove sticky columns so the entire table fits on small screens. Switch back to **Standard** for the default layout.
-
 ## Mobile layout
 
 When viewed on screens narrower than 768&nbsp;px each day collapses into a single column. AM and PM duties are stacked with a small divider for clarity. PGY information is shown as a badge next to the fellow's name instead of its own column.

--- a/index.html
+++ b/index.html
@@ -61,9 +61,6 @@
             max-height: 75vh;
             overflow-y: auto;
         }
-        .table-container.compact-view table {
-            min-width: 600px;
-        }
         table {
             width: 100%;
             border-collapse: collapse;
@@ -74,11 +71,6 @@
             text-align: left;
             border-bottom: 1px solid #e5e7eb;
             font-size: 0.875rem;
-        }
-        .compact-view th,
-        .compact-view td {
-            font-size: 0.625rem;
-            padding: 0.25rem;
         }
         th {
             background-color: var(--mizzou-black);
@@ -106,14 +98,6 @@
             max-width: 170px;
             overflow: hidden;
             text-overflow: ellipsis;
-        }
-        .compact-view thead th,
-        .compact-view tbody td {
-            position: static !important;
-            left: auto !important;
-        }
-        .compact-view tbody td:nth-child(1) {
-            min-width: auto;
         }
         /* Row styling */
         tr:nth-child(even) { background-color: var(--mizzou-gray-row); }
@@ -181,12 +165,6 @@
             padding: 0.25rem 0.5rem;
             border-radius: 0.25rem;
         }
-        .compact-view .orientation-cell,
-        .compact-view .holiday-cell,
-        .compact-view .july4-cell {
-            font-size: 0.625rem;
-            padding: 0.25rem;
-        }
 
         /* General holiday cell styling */
         .holiday-cell {
@@ -252,9 +230,6 @@
             .pgy-badge {
                 display: none;
             }
-            .view-mode-container {
-                display: none;
-            }
         }
         /* Loading spinner */
         .loading {
@@ -280,13 +255,6 @@
                 <label for="week-select" class="block text-lg font-medium text-gray-700 mb-2">Select Week</label>
                 <select id="week-select" class="w-full sm:w-auto">
                     <!-- Options will be populated by JavaScript -->
-                </select>
-            </div>
-            <div class="mt-4 sm:mt-0 view-mode-container">
-                <label for="view-select" class="block text-lg font-medium text-gray-700 mb-2">View Mode</label>
-                <select id="view-select" class="w-full sm:w-auto">
-                    <option value="standard">Standard</option>
-                    <option value="compact">Compact</option>
                 </select>
             </div>
         </div>
@@ -558,20 +526,10 @@ function createTableHeaders(startDate, mobile = false) {
             }
         }
 
-        function updateView() {
-            const container = document.getElementById('schedule-container');
-            const view = document.getElementById('view-select').value;
-            if (view === 'compact') {
-                container.classList.add('compact-view');
-            } else {
-                container.classList.remove('compact-view');
-            }
-        }
 
         // Initialize the application
         function init() {
             const weekSelect = document.getElementById('week-select');
-            const viewSelect = document.getElementById('view-select');
             const weeks = generateWeeks();
             
             // Populate dropdown
@@ -586,17 +544,14 @@ function createTableHeaders(startDate, mobile = false) {
             // Set current week
             const currentWeekIndex = getCurrentWeek(weeks);
             weekSelect.selectedIndex = currentWeekIndex;
-            viewSelect.value = 'standard';
             
             // Load the schedule for the selected week
             loadSchedule(weekSelect.value, weeks[currentWeekIndex].startDate);
-            updateView();
             
             // Handle week selection change
             weekSelect.addEventListener('change', (e) => {
                 loadSchedule(e.target.value, weeks[e.target.selectedIndex].startDate);
             });
-            viewSelect.addEventListener('change', updateView);
         }
 
 


### PR DESCRIPTION
## Summary
- drop the compact view selector
- clean up unused CSS and JS
- document automatic mobile view only

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685ccc6349f88333a1dfae1cc1ebbcd0