### PR TITLE
Modernize schedule styling

### DIFF
--- a/index.html
+++ b/index.html
@@ -6,30 +6,47 @@
     <title>Weekly Schedule - Mizzou GI</title>
     <script src="https://cdn.tailwindcss.com"></script>
     <style>
+        @import url('https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap');
         :root {
             --mizzou-black: #000000;
-            --mizzou-gold: #FFB612;
+            --mizzou-gold: #F1B82D;
             --mizzou-gold-dark: #C99700;
             --mizzou-gray: #f8f8f8;
             --mizzou-gray-row: #f2f2f2;
             --mizzou-hover-gold: #FFF8E1;
+            --umhs: #3b82f6;
+            --va: #10b981;
+            --clinic: #f97316;
+            --anes: #8b5cf6;
+            --research: #06b6d4;
+            --orientation: #eab308;
+            --holiday: #ef4444;
         }
         body {
             font-family: 'Inter', -apple-system, BlinkMacSystemFont, sans-serif;
-            background-color: var(--mizzou-gray);
+            background: #f9fafb;
         }
         .mizzou-header {
-            background-color: var(--mizzou-black);
-            color: var(--mizzou-gold);
-            padding: 0.75rem;
-            margin-bottom: 1rem;
+            background: linear-gradient(135deg, #000 0%, #1a1a1a 100%);
+            color: white;
+            padding: 1.5rem 0;
+            margin-bottom: 1.5rem;
             text-align: center;
+            box-shadow: 0 4px 6px -1px rgba(0, 0, 0, 0.1);
+        }
+
+        .mizzou-header p {
+            color: var(--mizzou-gold);
         }
         .controls {
             background-color: #ffffff;
-            padding: 0.75rem;
-            margin-bottom: 0.75rem;
+            padding: 1rem;
+            margin-bottom: 1.5rem;
             box-shadow: 0 1px 3px rgba(0, 0, 0, 0.1);
+            display: flex;
+            flex-direction: column;
+            align-items: center;
+            gap: 1rem;
         }
         select {
             padding: 0.375rem 0.5rem;
@@ -40,9 +57,10 @@
         }
         .table-container {
             background-color: white;
-            box-shadow: 0 1px 3px rgba(0, 0, 0, 0.1);
+            box-shadow: 0 4px 6px -1px rgba(0, 0, 0, 0.1);
             overflow-x: auto;
             -webkit-overflow-scrolling: touch;
+            border-radius: 12px;
         }
         
         /* Base table styles */
@@ -132,6 +150,7 @@
                 text-overflow: ellipsis;
                 position: relative;
                 gap: 0.0625rem;
+                border-radius: 0.25rem;
             }
             
             /* AM/PM indicators */
@@ -193,13 +212,45 @@
             }
             
             /* Color coding for different activities */
-            .umhs { color: #1e3a8a; }
-            .va { color: #166534; }
-            .clinic { color: #92400e; }
-            .anes { color: #5b21b6; }
-            .research { color: #0e7490; }
-            .orientation { color: #ea580c; background-color: #fef3c7; padding: 0 0.125rem; border-radius: 0.125rem; }
-            .holiday { font-size: 0.625rem; line-height: 1; }
+            .umhs {
+                background-color: rgba(59, 130, 246, 0.1);
+                color: var(--umhs);
+                border: 1px solid rgba(59, 130, 246, 0.3);
+            }
+            .va {
+                background-color: rgba(16, 185, 129, 0.1);
+                color: var(--va);
+                border: 1px solid rgba(16, 185, 129, 0.3);
+            }
+            .clinic {
+                background-color: rgba(249, 115, 22, 0.1);
+                color: var(--clinic);
+                border: 1px solid rgba(249, 115, 22, 0.3);
+            }
+            .anes {
+                background-color: rgba(139, 92, 246, 0.1);
+                color: var(--anes);
+                border: 1px solid rgba(139, 92, 246, 0.3);
+            }
+            .research {
+                background-color: rgba(6, 182, 212, 0.1);
+                color: var(--research);
+                border: 1px solid rgba(6, 182, 212, 0.3);
+            }
+            .orientation {
+                background-color: rgba(234, 179, 8, 0.1);
+                color: var(--orientation);
+                border: 1px solid rgba(234, 179, 8, 0.3);
+                border-radius: 0.25rem;
+            }
+            .holiday {
+                background-color: rgba(239, 68, 68, 0.1);
+                color: var(--holiday);
+                border: 1px solid rgba(239, 68, 68, 0.3);
+                font-size: 0.625rem;
+                line-height: 1;
+                border-radius: 0.25rem;
+            }
             
             /* Row stripes */
             tbody tr:nth-child(odd) { background-color: #ffffff; }
@@ -221,19 +272,27 @@
         /* Navigation buttons */
         .nav-buttons {
             display: flex;
-            gap: 0.5rem;
-            margin-top: 0.5rem;
+            gap: 0.75rem;
+            justify-content: center;
         }
         .nav-btn {
-            padding: 0.375rem 0.75rem;
-            background: #e5e7eb;
-            border: none;
-            border-radius: 0.25rem;
-            font-size: 0.75rem;
+            background: white;
+            border: 2px solid #e5e7eb;
+            border-radius: 10px;
+            padding: 0.75rem 1.25rem;
             cursor: pointer;
+            font-weight: 500;
+            color: #374151;
+            transition: all 0.2s;
+            box-shadow: 0 1px 3px rgba(0, 0, 0, 0.1);
+        }
+        .nav-btn:hover {
+            border-color: var(--mizzou-gold);
+            transform: translateY(-1px);
+            box-shadow: 0 4px 6px -1px rgba(0, 0, 0, 0.1);
         }
         .nav-btn:active {
-            background: #d1d5db;
+            transform: translateY(0);
         }
     </style>
 </head>


### PR DESCRIPTION
## Summary
- import Inter font and define color variables for rotations
- modernize header look and week navigation controls
- use gradient header and updated body background
- add colored backgrounds to schedule cells
- round shift blocks and adjust table container styling

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685e025685648333b95900705b1ac580