### PR TITLE
Fix master schedule link

### DIFF
--- a/index.html
+++ b/index.html
@@ -337,7 +337,7 @@
             <div class="nav-buttons">
                 <button id="prev-week" class="nav-btn">← Prev</button>
                 <button id="next-week" class="nav-btn">Next →</button>
-                <a href="https://www.mizzougi.com" class="nav-btn" target="_blank">Master Schedule</a>
+                <a href="https://www.mizzougi.com" class="nav-btn">Master Schedule</a>
             </div>
         </div>
 


### PR DESCRIPTION
## Summary
- remove `target="_blank"` so the Master Schedule opens in the same tab

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_68650ce5b04083339c226d8c5a55115d