### PR TITLE
Remove week numbers from dropdown options

### DIFF
--- a/index.html
+++ b/index.html
@@ -463,7 +463,7 @@
                 const numberStr = String(weekNumber).padStart(2, '0');
         
                 // Use the nice format for display
-                const weekString = `Week ${weekNumber} \u2022 ${formatDateNice(weekStart)} - ${formatDateNice(weekEnd)}`;
+                const weekString = `${formatDateNice(weekStart)} - ${formatDateNice(weekEnd)}`;
         
                 const fileName = `${numberStr}_week_${(weekStart.getMonth() + 1)}_${weekStart.getDate()}_${weekStart.getFullYear().toString().slice(-2)}.csv`;
 


### PR DESCRIPTION
## Summary
- simplify week label in dropdown

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_686766a3a5348333a2802775546ca058