### PR TITLE
Add schedule for week of June 29, 2026

### DIFF
--- a/53_week_6_29_26.csv
+++ b/53_week_6_29_26.csv
@@ -1,0 +1,11 @@
+NAME,PGY,AM,PM,AM,PM,AM,PM,AM,PM,AM,PM
+Tarar,6,UMHS-2,VA3,UMHS-2,UMHS-2,UMHS-2,UMHS-2,UMHS-2,UMHS-2,UMHS-2,UMHS-2
+Mansour,6,VA3,CC/JB,VA3,VA3,VA3,VA3,VA3,VA3,VA3,VA3
+Deda,6,EOD1,VA4,EOD1,EOD1,EOD1,EOD1,EOD1,EOD1,EOD1,EOD1
+Fard,5,VA2,VA2,VA2,CC/KA,VA2,VA2,VA2,VA2,VA2,VA1
+Gandhi,5,UMHS-1,UMHS-1,UMHS-1,UMHS-1,UMHS-1,UMHS-1,UMHS-1,UMHS-1,UMHS-1,UMHS-1
+Islam,5,Vacation,Vacation,Vacation,Vacation,Vacation,Vacation,Vacation,Vacation,Vacation,Vacation
+Ali,4,VA4,Amb/JB,VA4,VA2,VA4,Amb/AI,VA4,VA4,VA4,CC/KA
+Merchant,4,VA1,VA1,VA1,VA1,VA1,VA1,VA1,VA1,VA1,CC/KA
+Zaher,4,Research,Research,Research,CC/KA,Research,Research,Research,Research,Research,Research
+Mahdi,4,OUT,OUT,Amb/KA,VA4,Amb/AI,CC/PC,Amb/AI,Amb/AI,Amb/KA,VA4

--- a/index.html
+++ b/index.html
@@ -438,7 +438,7 @@
         function generateWeeks() {
             const weeks = [];
             let currentDate = new Date(2025, 5, 30);
-            const endDate = new Date(2026, 5, 26);
+            const endDate = new Date(2026, 6, 3);
             let weekNumber = 1;
 
             // Helper function for nice date formatting


### PR DESCRIPTION
## Summary
- add weekly schedule CSV for June 29, 2026
- extend week generation range to include the new week

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_688cd51fd0b08333ac53eda371e28773