### PR TITLE
Add schedule for week of 6/29/26

### DIFF
--- a/53_week_6_29_26.csv
+++ b/53_week_6_29_26.csv
@@ -1,0 +1,11 @@
+NAME,PGY,AM,PM,AM,PM,AM,PM,AM,PM,AM,PM
+Tarar,6,UMHS-2,VA3,UMHS-2,UMHS-2,UMHS-2,UMHS-2,UMHS-2,UMHS-2,UMHS-2,UMHS-2
+Mansour,6,VA3,CC/JB,VA3,VA3,VA3,VA3,VA3,VA3,VA3,VA3
+Deda,6,EOD1,VA4,EOD1,EOD1,EOD1,EOD1,EOD1,EOD1,EOD1,EOD1
+Fard,5,VA2,VA2,VA2,CC/KA,VA2,VA2,VA2,VA2,VA2,VA1
+Gandhi,5,UMHS-1,UMHS-1,UMHS-1,UMHS-1,UMHS-1,UMHS-1,UMHS-1,UMHS-1,UMHS-1,UMHS-1
+Islam,5,Vacation,Vacation,Vacation,Vacation,Vacation,Vacation,Vacation,Vacation,Vacation,Vacation
+Ali,4,VA4,Amb/JB,VA4,VA2,VA4,Amb/AI,VA4,VA4,VA4,CC/KA
+Merchant,4,VA1,VA1,VA1,VA1,VA1,VA1,VA1,VA1,VA1,CC/KA
+Zaher,4,Research,Research,Research,CC/KA,Research,Research,Research,Research,Research,Research
+Mahdi,4,OUT,OUT,Amb/KA,VA4,Amb/AI,CC/PC,Amb/AI,Amb/AI,Amb/KA,VA4

--- a/index.html
+++ b/index.html
@@ -438,7 +438,7 @@
         function generateWeeks() {
             const weeks = [];
             let currentDate = new Date(2025, 5, 30);
-            const endDate = new Date(2026, 5, 26);
+            const endDate = new Date(2026, 6, 3);
             let weekNumber = 1;
 
             // Helper function for nice date formatting


### PR DESCRIPTION
## Summary
- add CSV for week of June 29, 2026 with fellows' assignments
- extend schedule generation to include the week starting June 29, 2026

## Testing
- `python - <<'PY'
import csv
with open('53_week_6_29_26.csv') as f:
    rows=list(csv.reader(f))
print('rows:',len(rows))
print('first:',rows[0])
print('second:',rows[1])
PY`
- `python - <<'PY'
import csv
with open('53_week_6_29_26.csv') as f: rows=list(csv.reader(f))
print('names:', [r[0] for r in rows[1:]])
PY`


------
https://chatgpt.com/codex/tasks/task_e_6896255a7734833396b4f051a8f5302b